### PR TITLE
Update action runtime from Node.js 20 to Node.js 24

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -17,5 +17,5 @@ outputs:
   helmVersion: # id of output
     description: 'The next helm version'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary
- Update `runs.using` in `action.yaml` from `node20` to `node24`
- No code changes needed — the JS code uses only `@actions/core`, `@actions/github`, and `semver`, with no deprecated Node.js APIs

## Test plan
- [ ] Verify the action runs successfully in a workflow on Node.js 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)